### PR TITLE
smal fixes in different files

### DIFF
--- a/src/web/html/includes/footer.html
+++ b/src/web/html/includes/footer.html
@@ -1,6 +1,6 @@
 <div id="footer">
         <div class="left">
-        <a href="https://ahoydtu.de" target="_blank">AhoyDTU &copy 2024</a>
+        <a href="https://ahoydtu.de" target="_blank">AhoyDTU &copy; 2024</a>
         <ul>
             <li><a href="https://discord.gg/WzhxEY62mB" target="_blank">Discord</a></li>
             <li><a href="https://github.com/lumapu/ahoy" target="_blank">Github</a></li>

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -245,7 +245,7 @@
                             <p class="des">{#MQTT_NOTE}</p>
                             <div class="row mb-3">
                                 <div class="col-12 col-sm-3 my-2">{#INTERVAL}</div>
-                                <div class="col-12 col-sm-9"><input tyCMT2300Ape="number" name="mqttInterval" title="Invalid input" /></div>
+                                <div class="col-12 col-sm-9"><input type="number" name="mqttInterval" title="Invalid input" /></div>
                             </div>
                             <div class="row mb-3">
                                 <div class="col-12 col-sm-3 my-2">Discovery Config (homeassistant)</div>


### PR DESCRIPTION
some small fixes:

setup.html:
- input type wrong (come in this commit in: https://github.com/tictrick/ahoy/commit/a44a5833cae9f1c49134e72a315e892844693d43)

footer.html
- no semicolon for "&copy" => &copy;